### PR TITLE
Added polyfill and adjusted CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@fnndsc/chrisstoreapi": "^1.0.3",
+    "core-js": "^2.5.7",
     "express": "^4.16.3",
     "moment": "^2.22.2",
     "patternfly": "^3.51.0",

--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -59,9 +59,17 @@
   margin: 0 auto !important;
 }
 
-.text-light { color: var(--pf-black-500); }
+.text-light {
+  /* color */
+  color: #8b8d8f;
+  color: var(--pf-black-500);
+}
 
-.text-white { color: var(--pf-black-100); }
+.text-white {
+  /* color */
+  color: #fafafa;
+  color: var(--pf-black-100);
+}
 
 /* ============================== */
 /* ---------- RESPONSIVE -------- */

--- a/src/components/Developers/components/BashLine/BashLine.css
+++ b/src/components/Developers/components/BashLine/BashLine.css
@@ -8,6 +8,7 @@
 
 .bash-line-command {
   /* color */
+  background: #ededed;
   background: var(--pf-black-200);
 
   /* display */
@@ -21,6 +22,7 @@
   font-size: medium;
 
   /* border */
+  border-left-color: #00659c;
   border-left: 0.5em solid var(--pf-blue-500);
 
   /* other */

--- a/src/components/Developers/components/CopyToClipboard/CopyToClipboard.css
+++ b/src/components/Developers/components/CopyToClipboard/CopyToClipboard.css
@@ -1,5 +1,6 @@
 .copy-to-clipboard-btn {
   /* color */
+  background: #fafafa;
   background: var(--pf-black-100);
 
   /* display */

--- a/src/components/Developers/components/DeveloperCTA/DeveloperCTA.css
+++ b/src/components/Developers/components/DeveloperCTA/DeveloperCTA.css
@@ -1,6 +1,8 @@
 .developer-cta {
   /* color */
+  background: #393f44;
   background: var(--pf-black-800);
+  background: linear-gradient(135deg, #4d5258, #393f44);
   background: linear-gradient(135deg, var(--pf-black-700), var(--pf-black-800));
   background-image: url('../../../../assets/img/banner_chris.png');
   background-repeat: no-repeat;
@@ -19,6 +21,7 @@
 
 .developer-cta-header, .developer-cta-desc {
   /* color */
+  color: #fafafa;
   color: var(--pf-black-100);
 }
 
@@ -35,6 +38,7 @@
   /* font */
   font-weight: 600;
   font-size: medium;
+  text-shadow: 3px 3px 6px #030303;
   text-shadow: 3px 3px 6px var(--pf-black);
 }
 

--- a/src/components/Developers/components/Instructions/Instructions.css
+++ b/src/components/Developers/components/Instructions/Instructions.css
@@ -20,7 +20,11 @@
   float: right;
 }
 
-.instructions-steps { border-top: 1px solid var(--pf-black-300); }
+.instructions-steps {
+  /* border */
+  border-top-color: #d1d1d1;
+  border-top: 1px solid var(--pf-black-300); 
+}
 
 .instructions-step .instructions-number {
   /* font */
@@ -62,6 +66,7 @@
 
 .instructions-step pre {
   /* color */
+  background: #ededed;
   background: var(--pf-black-200);
 
   /* display */
@@ -75,10 +80,15 @@
   border: 0;
 }
 
-.instructions-step:not(:last-child) { border-bottom: 1px solid var(--pf-black-300); }
+.instructions-step:not(:last-child) {
+  /* border */
+  border-bottom-color: #d1d1d1;
+  border-bottom: 1px solid var(--pf-black-300);
+}
 
 .instructions-number > sub {
   /* color */
+  color: #8b8d8f;
   color: var(--pf-black-500);
 
   /* display */

--- a/src/components/Footer/Footer.css
+++ b/src/components/Footer/Footer.css
@@ -1,7 +1,10 @@
 .footer {
   /* color */
+  background: #292e34;
   background: var(--pf-black-900);
+  background: linear-gradient(#292e34, #030303);
   background: linear-gradient(var(--pf-black-900), var(--pf-black));
+  color: #fafafa;
   color: var(--pf-black-100);
 
   /* display */

--- a/src/components/Navbar/Navbar.css
+++ b/src/components/Navbar/Navbar.css
@@ -38,6 +38,7 @@ header .row > .navbar-header > .navbar-logo {
 
 .navbar-header > .navbar-search.search-pf {
   /* color */
+  color: #ededed;
   color: var(--pf-black-200);
   
   /* display */
@@ -71,7 +72,9 @@ header .row > .navbar-header > .navbar-logo {
 
 .navbar-search .form-group .form-control {
   /* color */
+  color: #ededed;
   color: var(--pf-black-200);
+  background: #292e34;
   background: var(--pf-black-900);
 
   /* display */
@@ -91,6 +94,7 @@ header .row > .navbar-header > .navbar-logo {
 
 .navbar-search .form-control::placeholder {
   /* color */
+  color: #ededed;
   color: var(--pf-black-200);
 
   /* font */
@@ -99,6 +103,7 @@ header .row > .navbar-header > .navbar-logo {
 
 .navbar-trigger {
   /* color */
+  color: #ededed;
   color: var(--pf-black-200);
 
   /* display */
@@ -117,11 +122,13 @@ header .row > .navbar-header > .navbar-logo {
 
 header .navbar.navbar-default .navbar-right > li > a:hover {
   /* color */
+  color: #d1d1d1;
   color: var(--pf-black-300);
 }
 
 header .navbar.navbar-default .navbar-right > li > a {
   /* color */
+  color: #fafafa;
   color: var(--pf-black-100);
 
   /* display */
@@ -140,6 +147,7 @@ header .navbar.navbar-default .navbar-right > li > button {
 
 header .navbar.navbar-default .navbar-right > li > a.active {
   /* color */
+  color: #fafafa;
   color: var(--pf-black-100);
 
   /* other */
@@ -158,6 +166,7 @@ header > .navbar-dropdown {
   background: #1d1d1d;
 
   /* border */
+  border-bottom-color: #393f44;
   border-bottom: 1px solid var(--pf-black-800);
 
   /* other */
@@ -177,6 +186,7 @@ header > .navbar-dropdown {
   padding: 0.5em;
   
   /* color */
+  color: #fafafa;
   color: var(--pf-black-100);
 
   /* font */
@@ -186,6 +196,7 @@ header > .navbar-dropdown {
 
 .navbar-dropdown-btn:hover {
   /* color */
+  background: #292e34;
   background: var(--pf-black-900);
 }
 
@@ -193,7 +204,9 @@ header > .navbar-dropdown {
 
 .navbar-dropdown-btn.active {
   /* color */
+  background: #030303;
   background: var(--pf-black);
+  color: #fafafa;
   color: var(--pf-black-100);
 
   /* other */
@@ -202,6 +215,7 @@ header > .navbar-dropdown {
 
 .navbar-btn-container .navbar-dropdown-btn:hover,
 .navbar-btn-container .navbar-dropdown-btn:focus {
+  color: #fafafa;
   color: var(--pf-black-100);
   text-decoration: none;
 }
@@ -241,6 +255,7 @@ header > .navbar-dropdown {
 
   .navbar-search > .has-icon .search-icon {
     /* color */
+    color: #d1d1d1;
     color: var(--pf-black-300);
 
     /* display */
@@ -254,6 +269,7 @@ header > .navbar-dropdown {
   .navbar-search .form-group .form-control {
     /* color */
     background: inherit;
+    color: #d1d1d1;
     color: var(--pf-black-300);
 
     /* display */
@@ -266,6 +282,7 @@ header > .navbar-dropdown {
 
   .navbar-search .form-control::placeholder {
     /* color */
+    color: #d1d1d1;
     color: var(--pf-black-300);
   }
 

--- a/src/components/Plugin/Plugin.css
+++ b/src/components/Plugin/Plugin.css
@@ -9,6 +9,7 @@
   padding: 1em;
 
   /* border */
+  border-bottom-color: #bbbbbb;
   border-bottom: 1px solid var(--pf-black-400);
 }
 
@@ -20,6 +21,7 @@
 
 .plugin-name {
   /* color */
+  color: #39a5dc;
   color: var(--pf-blue-300);
   
   /* font */
@@ -29,6 +31,7 @@
 
 .plugin-name:focus, .plugin-name:hover {
   /* color */
+  color: #0088ce;
   color: var(--pf-blue-400);
 
   /* font */
@@ -37,6 +40,7 @@
 
 .plugin-modified {
   /* color */
+  color: #bbbbbb;
   color: var(--pf-black-400);
 }
 
@@ -48,6 +52,7 @@
 
 .plugin-stats > .plugin-tag {
   /* color */
+  color: #8b8d8f;
   color: var(--pf-black-500);
   
   /* display */
@@ -56,6 +61,7 @@
   padding: 0 0.25em;
 
   /* border */
+  border-color: #8b8d8f;
   border: 1px solid var(--pf-black-500);
   border-radius: 4px;
 
@@ -68,10 +74,12 @@
 
 .plugin-author {
   /* color */
+  color: #8b8d8f;
   color: var(--pf-black-500);
 }
 
 .plugin-author:hover, .plugin-author:focus {
   /* color */
+  color: #72767b;
   color: var(--pf-black-600);
 }

--- a/src/components/Plugin/components/PluginBody/PluginBody.css
+++ b/src/components/Plugin/components/PluginBody/PluginBody.css
@@ -1,5 +1,6 @@
 .plugin-body {
   /* color */
+  background: #ededed;
   background: var(--pf-black-200);
   
   /* display */

--- a/src/components/Plugins/Plugins.css
+++ b/src/components/Plugins/Plugins.css
@@ -1,8 +1,10 @@
 .plugins-stats {
   /* color */
+  background: #f5f5f5;
   background: var(--pf-black-150);
   
   /* border */
+  border-bottom-color: #bbbbbb;
   border-bottom: 1px solid var(--pf-black-400);
 }
 
@@ -16,6 +18,7 @@
  
 .plugins-found {
   /* color */
+  color: #393f44;
   color: var(--pf-black-800);
   
   /* display */

--- a/src/components/Plugins/components/PluginItem/PluginItem.css
+++ b/src/components/Plugins/components/PluginItem/PluginItem.css
@@ -4,12 +4,14 @@
   padding: 0;
   
   /* border */
+  border-bottom-color: #ededed;
   border-bottom: 4px solid var(--pf-black-200);
   box-shadow: none;
 }
 
 .plugin-item-card-body {
   /* color */
+  color: #4d5258;
   color: var(--pf-black-700);
 
   /* font */
@@ -18,6 +20,7 @@
 
 .plugin-item-name {
   /* color */
+  color: #0088ce;
   color: var(--pf-blue-400);
   
   /* font */
@@ -35,6 +38,7 @@
 
 .plugin-item-creation {
   /* color */
+  color: #72767b;
   color: var(--pf-black-600);
 
   /* font */
@@ -43,9 +47,11 @@
 
 .plugin-item-author {
   /* color */
+  color: #4d5258;
   color: var(--pf-black-700);
 
   /* border */
+  border-bottom-color: #d1d1d1;
   border-bottom: 1px solid var(--pf-black-300);
 
   /* font */
@@ -54,6 +60,7 @@
 
 .plugin-item-author:hover,
 .plugin-item-author:focus {
+  color: #4d5258;
   color: var(--pf-black-700);
   text-decoration: none;
 }

--- a/src/components/Plugins/components/PluginsCategories/PluginsCategories.css
+++ b/src/components/Plugins/components/PluginsCategories/PluginsCategories.css
@@ -8,6 +8,7 @@
 
 .plugins-categories-header {
   /* color */
+  color: #4d5258;
   color: var(--pf-black-700);
 
   /* display */
@@ -20,11 +21,13 @@
   font-weight: 600;
   
   /* border */
+  border-bottom-color: #4d5258;
   border-bottom: 3px solid var(--pf-black-700);
 }
 
 .plugins-category {
   /* color */
+  color: #0088ce;
   color: var(--pf-blue-400);
 
   /* display */

--- a/src/components/Welcome/components/WelcomeCTA/WelcomeCTA.css
+++ b/src/components/Welcome/components/WelcomeCTA/WelcomeCTA.css
@@ -4,18 +4,22 @@
 
 .welcome-cta-img {
   /* color */
+  background: #393f44;
   background: var(--pf-black-800);
+  background: linear-gradient(135deg #4d5258, #393f44);
   background: linear-gradient(135deg, var(--pf-black-700), var(--pf-black-800));
   background-image: url('../../../../assets/img/banner_chris-users.png');
   background-repeat: no-repeat;
   background-size: cover;
   background-position: center;
+  color: #fafafa;
   color: var(--pf-black-100);
 
   /* display */
   padding: 3em 30px;
 
   /* font */
+  text-shadow: 3px 3px 6px #030303;
   text-shadow: 3px 3px 6px var(--pf-black);
 
   /* vertically align text in div */
@@ -32,7 +36,9 @@
 
 .welcome-cta-featured {
   /* color */
+  background: #0088ce;
   background: var(--pf-blue-400);
+  background: linear-gradient(#39a5dc, #0088ce);
   background: linear-gradient(var(--pf-blue-300), var(--pf-blue-400));
 
   /* display */
@@ -42,6 +48,7 @@
 
 .welcome-cta-featured-desc {
   /* color */
+  color: #fafafa;
   color: var(--pf-black-100);
 
   /* display */
@@ -68,6 +75,7 @@
 
 .welcome-scroll-caret {
   /* color */
+  color: #fafafa;
   color: var(--pf-black-100);
 
   /* display */

--- a/src/components/Welcome/components/WelcomeCategories/welcomeCategories.css
+++ b/src/components/Welcome/components/WelcomeCategories/welcomeCategories.css
@@ -1,6 +1,8 @@
 .welcome-categories {
   /* color */
+  background: #393f44;
   background: var(--pf-black-800);
+  background: linear-gradient(135deg, #4d5258, #393f44);
   background: linear-gradient(135deg, var(--pf-black-700), var(--pf-black-800));
   background-image: url('../../../../assets/img/banner_background-categories.png');
   background-repeat: repeat;
@@ -13,6 +15,7 @@
 
 .welcome-categories-header {
   /* color */
+  color: #fafafa;
   color: var(--pf-black-100);
 
   /* display */
@@ -21,6 +24,7 @@
   /* font */
   text-align: left;
   font-size: 2em;
+  text-shadow: 0 0 1em #030303;;
   text-shadow: 0 0 1em var(--pf-black);
 }
 

--- a/src/components/Welcome/components/WelcomeCategory/WelcomeCategory.css
+++ b/src/components/Welcome/components/WelcomeCategory/WelcomeCategory.css
@@ -1,5 +1,6 @@
 .welcome-categories-container > .welcome-category {
   /* border */
+  border-top-color: #39a5dc;
   border-top: 4px solid var(--pf-blue-300);
 }
 
@@ -27,6 +28,7 @@
 
 .welcome-category-item-name {
   /* color */
+  color: #39a5dc;
   color: var(--pf-blue-300);
 
   /* font */
@@ -36,6 +38,7 @@
 
 .welcome-category-item-desc {
   /* color */
+  color: #8b8d8f;
   color: var(--pf-black-500);
 
   /* font */
@@ -45,7 +48,11 @@
   text-overflow: ellipsis;
 }
 
-.welcome-category-item-tags { color: var(--pf-black-300); }
+.welcome-category-item-tags {
+  /* color */
+  color: #d1d1d1;
+  color: var(--pf-black-300);
+}
 
 /* ============================== */
 /* ---------- RESPONSIVE -------- */

--- a/src/components/Welcome/components/WelcomeChRIS/WelcomeChRIS.css
+++ b/src/components/Welcome/components/WelcomeChRIS/WelcomeChRIS.css
@@ -1,5 +1,6 @@
 .welcome-chris {
   /* color */
+  background: #39a5dc;
   background: var(--pf-blue-300);
 
   /* display */
@@ -18,7 +19,11 @@
   flex: 1;
 }
 
-.welcome-chris-text { color: var(--pf-black-100); }
+.welcome-chris-text {
+  /* color */
+  color: #fafafa;
+  color: var(--pf-black-100);
+}
 
 .welcome-chris-text-container > div {
   font-weight: 400;
@@ -43,7 +48,11 @@
 }
 
 .welcome-chris-video-desc {
+  /* color */
+  color: #fafafa;
   color: var(--pf-black-100);
+
+  /* display */
   padding: 1em 1em 0 0;
 }
 

--- a/src/components/Welcome/components/WelcomeFeature/WelcomeFeature.css
+++ b/src/components/Welcome/components/WelcomeFeature/WelcomeFeature.css
@@ -15,6 +15,7 @@
 
 .welcome-feature-text {
   /* color */
+  color: #fafafa;
   color: var(--pf-black-100);
 
   /* font */

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+
+/* polyfills */
+import 'core-js/fn/array/includes';
+
 import './index.css';
 import App from './components/App/App';
 import registerServiceWorker from './registerServiceWorker';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1970,7 +1970,7 @@ core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
-core-js@^2.4.0, core-js@^2.5.0:
+core-js@^2.4.0, core-js@^2.5.0, core-js@^2.5.7:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
 


### PR DESCRIPTION
Internet Explorer 11 does not have support for CSS custom properties. This pull request adds necessary polyfills (using core-js) and adds CSS properties without variables to each corresponding CSS custom property.

Resolves #4