### PR TITLE
Fix serve.js default port to work with ChRIS_store backend

### DIFF
--- a/serve.js
+++ b/serve.js
@@ -3,7 +3,7 @@ const express = require('express');
 const { join } = require('path');
 
 // constants
-const PORT = process.env.PORT || 8080;
+const PORT = process.env.PORT || 3000;
 const HOST = process.env.HOST || '0.0.0.0';
 
 // serve static files


### PR DESCRIPTION
The ChRIS_store backend is hosted on port 8080 and so the old serve.js default port conflicted with it.

*(For future reference, you can also use the PORT environment variable to customize the port)*