### PR TITLE
Found and fixed 404 on signin page

### DIFF
--- a/src/components/SignIn/SignIn.js
+++ b/src/components/SignIn/SignIn.js
@@ -147,7 +147,7 @@ class SignIn extends Component {
                 </Button>
                 <p className="login-pf-signup">
                   Need an account?
-                  <Link to="/signup" href="/signup">
+                  <Link to="/developers" href="/developers">
                     Signup
                   </Link>
                 </p>

--- a/src/components/SignIn/__snapshots__/SignIn.test.js.snap
+++ b/src/components/SignIn/__snapshots__/SignIn.test.js.snap
@@ -111,9 +111,9 @@ ShallowWrapper {
                                 >
                                         Need an account?
                                         <Link
-                                                href="/signup"
+                                                href="/developers"
                                                 replace={false}
-                                                to="/signup"
+                                                to="/developers"
                                         >
                                                 Signup
                                         </Link>
@@ -223,9 +223,9 @@ ShallowWrapper {
                                     >
                                                 Need an account?
                                                 <Link
-                                                            href="/signup"
+                                                            href="/developers"
                                                             replace={false}
-                                                            to="/signup"
+                                                            to="/developers"
                                                 >
                                                             Signup
                                                 </Link>
@@ -369,9 +369,9 @@ ShallowWrapper {
                                 >
                                                 Need an account?
                                                 <Link
-                                                                href="/signup"
+                                                                href="/developers"
                                                                 replace={false}
-                                                                to="/signup"
+                                                                to="/developers"
                                                 >
                                                                 Signup
                                                 </Link>
@@ -470,9 +470,9 @@ ShallowWrapper {
                   >
                                     Need an account?
                                     <Link
-                                                      href="/signup"
+                                                      href="/developers"
                                                       replace={false}
-                                                      to="/signup"
+                                                      to="/developers"
                                     >
                                                       Signup
                                     </Link>
@@ -537,9 +537,9 @@ ShallowWrapper {
 >
                       Need an account?
                       <Link
-                                            href="/signup"
+                                            href="/developers"
                                             replace={false}
-                                            to="/signup"
+                                            to="/developers"
                       >
                                             Signup
                       </Link>
@@ -660,9 +660,9 @@ ShallowWrapper {
                       "children": Array [
                         "Need an account?",
                         <Link
-                          href="/signup"
+                          href="/developers"
                           replace={false}
-                          to="/signup"
+                          to="/developers"
 >
                           Signup
 </Link>,
@@ -678,9 +678,9 @@ ShallowWrapper {
                         "nodeType": "class",
                         "props": Object {
                           "children": "Signup",
-                          "href": "/signup",
+                          "href": "/developers",
                           "replace": false,
-                          "to": "/signup",
+                          "to": "/developers",
                         },
                         "ref": null,
                         "rendered": "Signup",
@@ -802,9 +802,9 @@ ShallowWrapper {
                                         >
                                                   Need an account?
                                                   <Link
-                                                            href="/signup"
+                                                            href="/developers"
                                                             replace={false}
-                                                            to="/signup"
+                                                            to="/developers"
                                                   >
                                                             Signup
                                                   </Link>
@@ -914,9 +914,9 @@ ShallowWrapper {
                                           >
                                                         Need an account?
                                                         <Link
-                                                                      href="/signup"
+                                                                      href="/developers"
                                                                       replace={false}
-                                                                      to="/signup"
+                                                                      to="/developers"
                                                         >
                                                                       Signup
                                                         </Link>
@@ -1060,9 +1060,9 @@ ShallowWrapper {
                                     >
                                                       Need an account?
                                                       <Link
-                                                                        href="/signup"
+                                                                        href="/developers"
                                                                         replace={false}
-                                                                        to="/signup"
+                                                                        to="/developers"
                                                       >
                                                                         Signup
                                                       </Link>
@@ -1161,9 +1161,9 @@ ShallowWrapper {
                     >
                                         Need an account?
                                         <Link
-                                                            href="/signup"
+                                                            href="/developers"
                                                             replace={false}
-                                                            to="/signup"
+                                                            to="/developers"
                                         >
                                                             Signup
                                         </Link>
@@ -1228,9 +1228,9 @@ ShallowWrapper {
 >
                         Need an account?
                         <Link
-                                                href="/signup"
+                                                href="/developers"
                                                 replace={false}
-                                                to="/signup"
+                                                to="/developers"
                         >
                                                 Signup
                         </Link>
@@ -1351,9 +1351,9 @@ ShallowWrapper {
                         "children": Array [
                           "Need an account?",
                           <Link
-                            href="/signup"
+                            href="/developers"
                             replace={false}
-                            to="/signup"
+                            to="/developers"
 >
                             Signup
 </Link>,
@@ -1369,9 +1369,9 @@ ShallowWrapper {
                           "nodeType": "class",
                           "props": Object {
                             "children": "Signup",
-                            "href": "/signup",
+                            "href": "/developers",
                             "replace": false,
-                            "to": "/signup",
+                            "to": "/developers",
                           },
                           "ref": null,
                           "rendered": "Signup",


### PR DESCRIPTION
This fixes issue: https://github.com/FNNDSC/ChRIS_store_ui/issues/26

When the user clicks create account, reroute the user to the dev page to sign up for an account rather than the non-existent signup page.