### PR TITLE
Quick fix for alignment issue of cards in dashboard.

### DIFF
--- a/src/components/Dashboard/components/DashGitHubView/DashGitHubView.css
+++ b/src/components/Dashboard/components/DashGitHubView/DashGitHubView.css
@@ -1,6 +1,12 @@
 @media (min-width: 598px) {
     .github-card-body {
-        min-height: 68vh;
+        min-height: 711px;
+    }
+}
+
+@media (min-width: 992px) {
+    .github-card-body {
+        min-height: 573px;
     }
 }
 


### PR DESCRIPTION
Align git history card height when resizing the page.