### PR TITLE
Remove username from the disableControls logic

### DIFF
--- a/src/components/Developers/components/DeveloperSignup/DeveloperSignup.js
+++ b/src/components/Developers/components/DeveloperSignup/DeveloperSignup.js
@@ -153,11 +153,11 @@ export class DeveloperSignup extends Component {
       loading,
       toDashboard,
     } = this.state;
-    const { store } = this.props;
+
     if (toDashboard) {
       return <Redirect to="/dashboard" />;
     }
-    const disableControls = loading || store.get('userName') == null;
+    const disableControls = loading;
     return (
       <Form onSubmit={this.handleSubmit} noValidate>
         <p>{loading ? 'Creating' : 'Create'} a ChRIS Developer account:</p>


### PR DESCRIPTION
The disableControls checks both the loading state and username state before and this route has been abandoned. Username is not needed for the logic check.