### PR TITLE
Remove recompose

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "react-dom": "16.4.1",
     "react-router-dom": "^4.3.1",
     "react-scripts": "3.4.3",
-    "recompose": "^0.30.0",
     "rxjs": "^6.3.3",
     "sortabular": "^1.6.0",
     "table-resolver": "^4.1.1",

--- a/src/components/Dashboard/components/DashTeamView/DashTeamView.js
+++ b/src/components/Dashboard/components/DashTeamView/DashTeamView.js
@@ -4,7 +4,6 @@ import orderBy from 'lodash/orderBy';
 import PropTypes from 'prop-types';
 import * as sort from 'sortabular';
 import * as resolve from 'table-resolver';
-import { compose } from 'recompose';
 import {
   actionHeaderCellFormatter,
   customHeaderFormattersDefinition,
@@ -193,12 +192,12 @@ class DashTeamView extends Component {
     const { rows, sortingColumns, columns } = this.state;
     const showEmptyState = isEmpty(plugins);
 
-    const sortedRows = compose(sort.sorter({
+    const sortedRows = sort.sorter({
       columns,
       sortingColumns,
       sort: orderBy,
       strategy: sort.strategies.byProperty,
-    }))(rows);
+    })(rows);
 
     return (
       <Col sm={12}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9888,7 +9888,7 @@ react-is@^16.8.1, react-is@^16.8.4:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
+react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
@@ -10180,17 +10180,6 @@ recompose@^0.26.0:
     change-emitter "^0.1.2"
     fbjs "^0.8.1"
     hoist-non-react-statics "^2.3.1"
-    symbol-observable "^1.0.4"
-
-recompose@^0.30.0:
-  version "0.30.0"
-  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.30.0.tgz#82773641b3927e8c7d24a0d87d65aeeba18aabd0"
-  dependencies:
-    "@babel/runtime" "^7.0.0"
-    change-emitter "^0.1.2"
-    fbjs "^0.8.1"
-    hoist-non-react-statics "^2.3.1"
-    react-lifecycles-compat "^3.0.2"
     symbol-observable "^1.0.4"
 
 recursive-readdir@2.2.2:


### PR DESCRIPTION
To my knowledge, `compose()` called with only one argument does nothing.

There is only one use of `recompose` in the code which I have removed.

Solves #108, which I opened hastily without first looking at the code.