### PR TITLE
Card text made responsive in small screens

### DIFF
--- a/src/components/Plugin/components/PluginBody/PluginBody.css
+++ b/src/components/Plugin/components/PluginBody/PluginBody.css
@@ -11,6 +11,11 @@
   display: flex;
 }
 
+.plugin-body-combined-cols{
+  display: flex;
+  flex-direction: row;
+}
+
 .plugin-tab>.active {
   display: flex !important;
   flex: 1;
@@ -67,6 +72,22 @@
   }
 }
 
+@media (max-width: 768px){
+  
+  .plugin-body-combined-cols{
+    display: flex;
+    flex-direction: column;
+  }
+  
+  .plugin-body-main-col { 
+    max-width: 100%;
+   }
+
+  .plugin-body-side-col { 
+    max-width: 100%; 
+  }
+
+}
 .plugin-body-nav-tabs>li>a{
   padding-top: 20px !important;
   padding-bottom: 20px !important;

--- a/src/components/Plugin/components/PluginBody/PluginBody.js
+++ b/src/components/Plugin/components/PluginBody/PluginBody.js
@@ -32,6 +32,7 @@ const PluginBody = ({ pluginData }) => (
                     </Nav>
                     <TabContent animation className="plugin-tab">
                       <TabPane eventKey={1}>
+                      <div className="plugin-body-combined-cols">
                         <div className="plugin-body-main-col">
                           <div className="plugin-body-readme">
                             README.rst
@@ -181,6 +182,7 @@ const PluginBody = ({ pluginData }) => (
                             7 July 2020
                           </div>
                         </div>
+                      </div>
                       </TabPane>
                       <TabPane eventKey={2}>Parameters content</TabPane>
                       <TabPane eventKey={3}>Versions content</TabPane>


### PR DESCRIPTION
## Description
Card text made stackable in smaller screen view. Both create-plugin and plugin-body are responsive
Fixes: #140 
## Screenshots
![image](https://user-images.githubusercontent.com/66299533/114808013-161c3e80-9dc5-11eb-8e39-8bb2fc7ca224.png)
![image](https://user-images.githubusercontent.com/66299533/114808067-2d5b2c00-9dc5-11eb-9e09-f56f2b049ad2.png)
