### PR TITLE
Updated plugin body

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "core-js": "^2.5.7",
     "email-validator": "^2.0.4",
     "lodash": "^4.17.19",
+    "marked": "^2.0.3",
     "moment": "^2.22.2",
     "patternfly": "^3.58.0",
     "patternfly-react": "^2.24.0",

--- a/src/components/Plugin/Plugin.css
+++ b/src/components/Plugin/Plugin.css
@@ -116,9 +116,6 @@
 }
 
 .plugin-stats {
-  /* display */
-  margin-left: 1em;
-
   /* color */
   color: var(--pf-black-400, #bbb);
 }

--- a/src/components/Plugin/Plugin.js
+++ b/src/components/Plugin/Plugin.js
@@ -183,14 +183,14 @@ export class Plugin extends Component {
             <Grid>
               <Grid.Row>
                 <Grid.Col sm={12}>
-                  <Grid.Col sm={1}>
+                  <Grid.Col sm={2}>
                     <img
                       className="plugin-icon"
                       src={PluginImg}
                       alt="Plugin icon"
                     />
                   </Grid.Col>
-                  <Grid.Col sm={6}>
+                  <Grid.Col sm={10}>
                     <div className="plugin-category">
                       Visualization
                     </div>
@@ -207,24 +207,24 @@ export class Plugin extends Component {
                     <div className="plugin-description">
                       {data.description}
                     </div>
-                  </Grid.Col>
-                  <Grid.Col sm={4} className="plugin-stats">
-                    <Icon name="star" size="lg" />
-                    {' '}
-                    10k+
-                    {modificationDate.isValid()
-                      && (
+                    <div className="plugin-stats">
+                      <Icon name="star" size="lg" />
+                      {' '}
+                      10k+
+                      {modificationDate.isValid()
+                        && (
+                        <span className="plugin-modified">
+                          <Icon name="clock-o" size="lg" />
+                          {`Last modified ${modificationDate.format()}`}
+                        </span>
+                        )}
+                      {/* temp text */}
                       <span className="plugin-modified">
                         <Icon name="clock-o" size="lg" />
-                        {`Last modified ${modificationDate.format()}`}
+                        {' '}
+                        Last modified 1 hour ago
                       </span>
-                      )}
-                    {/* temp text */}
-                    <span className="plugin-modified">
-                      <Icon name="clock-o" size="lg" />
-                      {' '}
-                      Last modified 1 hour ago
-                    </span>
+                    </div>
                   </Grid.Col>
                 </Grid.Col>
               </Grid.Row>

--- a/src/components/Plugin/components/PluginBody/PluginBody.css
+++ b/src/components/Plugin/components/PluginBody/PluginBody.css
@@ -2,9 +2,6 @@
   /* color */
   background: #ededed;
   background: var(--pf-black-200);
-
-  /* display */
-  padding: 1em;
 }
 
 .plugin-tab {
@@ -44,27 +41,33 @@
   padding-right: .5em;
 }
 
-.plugin-body-main-col { flex: 5; }
-
-.plugin-body-side-col { flex: 2; }
-
-.plugin-body-side-col > div {
-  margin-bottom: 60px;
+#plugin-body-container {
+  display: grid;
+  grid-template-columns: 3fr 1fr;
+  gap: 1em;
 }
 
-.plugin-body-side-col > div:last-child {
-  margin-bottom: 0;
+#plugin-body-container .plugin-body-main-col {
+  grid-column: 1 / 2;
+}
+#plugin-body-container .plugin-body-side-col {
+  grid-column: 2 / 3;
 }
 
-.plugin-body-contributors-all {
-  margin-top: 40px;
-}
-
-@media (min-width: 768px) {
-  .plugin-body-main-col {
-    /* display */
-    padding-right: 1.2em;
+@media (max-width: 1200px) {
+  #plugin-body-container {
+    display: flex;
+    flex-direction: column;
   }
+}
+
+.plugin-body-side-col .plugin-body-detail-section {
+  margin-top: 1em;
+  border-bottom: 1px solid lightgray;
+  padding: 1em 0;
+}
+.plugin-body-detail-section h4 {
+  font-weight: bold;
 }
 
 .plugin-body-nav-tabs>li>a{

--- a/src/components/Plugin/components/PluginBody/PluginBody.js
+++ b/src/components/Plugin/components/PluginBody/PluginBody.js
@@ -1,209 +1,138 @@
 /* eslint-disable react/jsx-indent-props */
 /* eslint-disable react/jsx-indent */
-import React from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
+import marked from 'marked';
 import {
   Grid, Nav, NavItem, TabContainer, TabContent, TabPane,
 } from 'patternfly-react';
+
+
 import './PluginBody.css';
 import { CopyURLButton } from '../../../general/CopyURLButton';
 
-const PluginBody = ({ pluginData }) => (
-  <div className="plugin-body">
-    <div className="container-fluid container-cards-pf">
-      <div className="row row-cards-pf">
-        <Grid>
-          <Grid.Row>
-            <Grid.Col sm={12}>
-              <div className="card-pf">
-                <TabContainer id="basic-tabs" defaultActiveKey={1}>
-                  <div>
-                    <Nav className="nav nav-tabs nav-tabs-pf plugin-body-nav-tabs">
-                      <NavItem eventKey={1}>
-                        Overview
-                      </NavItem>
-                      <NavItem eventKey={2}>
-                        Parameters
-                      </NavItem>
-                      <NavItem eventKey={3}>
-                        Versions
-                      </NavItem>
-                    </Nav>
-                    <TabContent animation className="plugin-tab">
-                      <TabPane eventKey={1}>
-                        <div className="plugin-body-main-col">
-                          <div className="plugin-body-readme">
-                            README.rst
-                          </div>
-                          <h1 className="pf-c-title pf-m-4xl plugin-body-title">
-                            {pluginData.title}
-                          </h1>
-                          <div className="plugin-body-toc">
-                            <h3 className="pf-c-title pf-m-2xl">Table of Contents</h3>
-                            <ul className="pf-c-list">
-                              <li>
-                                <Link
-                                  href={pluginData.title}
-                                  to={pluginData.title}
-                                >
-                                  Abstract
-                                </Link>
-                              </li>
-                              <li>
-                                <Link
-                                  href={pluginData.title}
-                                  to={pluginData.title}
-                                >
-                                  Synopsis
-                                </Link>
-                              </li>
-                              <li>
-                                <Link
-                                  href={pluginData.title}
-                                  to={pluginData.title}
-                                >
-                                  Run
-                                </Link>
-                                <ul>
-                                  <li>
-                                    <Link
-                                      href={pluginData.title}
-                                      to={pluginData.title}
-                                    >
-                                      Using PyPi
-                                    </Link>
-                                  </li>
-                                  <li>
-                                    <Link
-                                      href={pluginData.title}
-                                      to={pluginData.title}
-                                    >
-                                      Using
-                                      <code>docker run</code>
-                                    </Link>
-                                  </li>
-                                </ul>
-                              </li>
-                              <li>
-                                <Link
-                                  href={pluginData.title}
-                                  to={pluginData.title}
-                                >
-                                  Examples
-                                </Link>
-                                <ul className="pf-c-list">
-                                  <li>
-                                    <Link
-                                      href={pluginData.title}
-                                      to={pluginData.title}
-                                    >
-                                      Check available pre-processed runs
-                                    </Link>
-                                  </li>
-                                  <li>
-                                    <Link
-                                      href={pluginData.title}
-                                      to={pluginData.title}
-                                    >
-                                      Copy the default for a selected pre-processed run
-                                    </Link>
-                                  </li>
-                                </ul>
-                              </li>
-                            </ul>
-                          </div>
-                          <div className="plugin-body-content">
-                            <h2 className="pf-c-title pf-m-3xl">Abstract</h2>
-                            <hr />
-                            <p>
-                              {/* eslint-disable-next-line */}
-                              <code>freesurfer_pp_moc.py</code> is a dummy FreeSurver plugin/container that is prepopulated with the results of several priori FreeSurfer runs. For a given run, this script will simply copy elements of one of these prior runs to the output directory.
-                            </p>
-                            <h2 className="pf-c-title pf-m-3xl">Synopsis</h2>
-                            <hr />
-                            <p>
-                              <code>
-                                python freesurfer_pp.py
-                                {/* eslint-disable-next-line */}
-                                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-                              </code>
-                            </p>
-                          </div>
-                        </div>
-                        <div className="plugin-body-side-col">
-                        <div className="plugin-body-copy-url">
-                          <CopyURLButton className="pf-c-button pf-m-primary" text={pluginData.url} />
-                        </div>
-                          <div className="plugin-body-public-repo">
-                            <h4>Public Repo:</h4>
-                            <Link
-                              href={pluginData.public_repo}
-                              to={pluginData.public_repo}
-                              className="pf-c-button pf-m-link"
-                            >
-                              {pluginData.public_repo}
-                            </Link>
-                          </div>
-                          <div className="plugin-body-documentation">
-                            <h4>Documentation:</h4>
-                            {/* eslint-disable-next-line */}
-                            <a className="pf-c-button pf-m-link">
-                              readthedocs.com/freesurfer
-                            </a>
-                          </div>
-                          <div className="plugin-body-contributors">
-                            <h4>Contributors (20):</h4>
-                            <a
-                              href={pluginData.authorURL}
-                              className="pf-c-button pf-m-link" type="button">
-                              <span className="pf-c-button__icon pf-m-start">
-                                <i className="fas fa-user" aria-hidden="true"></i>
-                              </span>
-                              {pluginData.authors}
-                            </a>
-                            {/* <Icon name="user" size="lg" />
-                            <Link
-                              href={pluginData.authorURL}
-                              to={pluginData.authors}
-                              className="pf-c-button pf-m-link"
-                            >
-                              {pluginData.authors}
-                            </Link> */}
-                            <div className="plugin-body-contributors-all">
-                              {/* eslint-disable-next-line */}
-                              <a className="pf-c-button pf-m-link">
-                                View all contributors...
-                              </a>
+const PluginBody = ({ pluginData }) => {
+  const [readme, setReadme] = useState();
+  const [repoData, setRepoData] = useState();
+
+  const fetchReadme = useCallback(async (repo) => {
+    const data = await fetch(`https://api.github.com/repos/${repo}/community/profile`)
+    const rm = await fetch((await data.json()).files.readme.url)
+    const download = await fetch((await rm.json()).download_url)
+    setReadme(await download.text())
+  }, [])
+
+  const fetchRepoData = useCallback(async (repo) => {
+    const data = await fetch(`https://api.github.com/repos/${repo}`)
+    setRepoData(await data.json())
+    fetchReadme(repo)
+  }, [fetchReadme])
+
+  useEffect(() => {
+    const expectRepoName = pluginData.public_repo.split('github.com/')[1];
+    if (expectRepoName)
+      fetchRepoData(expectRepoName)
+    else
+      return () => {
+        setRepoData(undefined)
+      }
+  }, [fetchRepoData, pluginData.public_repo])
+
+  return (
+    <div className="plugin-body">
+      <div className="container-fluid container-cards-pf">
+        <div className="row row-cards-pf">
+          <Grid>
+            <Grid.Row>
+              <Grid.Col sm={12}>
+                <div className="card-pf">
+                  <TabContainer id="basic-tabs" defaultActiveKey={1}>
+                    <div>
+                      <Nav className="nav nav-tabs nav-tabs-pf plugin-body-nav-tabs">
+                        <NavItem eventKey={1}>
+                          Overview
+                        </NavItem>
+                        <NavItem eventKey={2}>
+                          Parameters
+                        </NavItem>
+                        <NavItem eventKey={3}>
+                          Versions
+                        </NavItem>
+                      </Nav>
+                      <TabContent animation className="plugin-tab">
+                        <TabPane eventKey={1}>
+                          <div id="plugin-body-container">
+                            <div className="plugin-body-main-col">
+                              <div className="plugin-body-readme">
+                                README
+                              </div>
+                              { readme ? <div dangerouslySetInnerHTML={{ __html: marked(readme) }}></div> : null }
+                            </div>
+                            <div className="plugin-body-side-col">
+                              <div className="plugin-body-copy-url">
+                                <CopyURLButton className="pf-c-button pf-m-primary" text={pluginData.url} />
+                              </div>
+                              <div className="plugin-body-detail-section">
+                                <h4>Public Repo</h4>
+                                <a href={pluginData.public_repo}>
+                                  {pluginData.public_repo}
+                                </a>
+                              </div>
+                              <div className="plugin-body-detail-section">
+                                <h4>Documentation</h4>
+                                <a className="pf-c-button pf-m-link" href="readthedocs.com/freesurfer">
+                                  readthedocs.com/freesurfer
+                                </a>
+                              </div>
+                              <div className="plugin-body-detail-section">
+                                <h4>Contributors</h4>
+                                <a href={pluginData.authorURL}
+                                  className="pf-m-link" type="button">
+                                  <span className="pf-c-button__icon pf-m-start">
+                                    <i className="fas fa-user" aria-hidden="true"></i>
+                                  </span>
+                                  {pluginData.authors}
+                                </a>
+                                <div className="plugin-body-contributors-all">
+                                  <a className="pf-m-link" href={repoData ? repoData.contributors_url : ''}>
+                                    View all contributors...
+                                  </a>
+                                </div>
+                              </div>
+                              <div className="plugin-body-detail-section">
+                                <h4>Plugin ID</h4>
+                                {pluginData.id}
+                              </div>
+                              <div className="plugin-body-detail-section">
+                                <h4>License</h4>
+                                { repoData ? repoData.license.name : pluginData.license }
+                              </div>
+                              <div className="plugin-body-detail-section">
+                                <h4>Content Type</h4>
+                                {pluginData.type}
+                              </div>
+                              <div className="plugin-body-detail-section">
+                                <h4>Date added</h4>
+                                7 July 2020
+                              </div>
                             </div>
                           </div>
-                          <div className="plugin-body-license">
-                            <h4>License:</h4>
-                            {pluginData.license}
-                          </div>
-                          <div className="plugin-body-content-type">
-                            <h4>Content Type:</h4>
-                            {pluginData.type}
-                          </div>
-                          <div className="plugin-body-date-added">
-                            <h4>Date added:</h4>
-                            7 July 2020
-                          </div>
-                        </div>
-                      </TabPane>
-                      <TabPane eventKey={2}>Parameters content</TabPane>
-                      <TabPane eventKey={3}>Versions content</TabPane>
-                    </TabContent>
-                  </div>
-                </TabContainer>
-              </div>
-            </Grid.Col>
-          </Grid.Row>
-        </Grid>
+                        </TabPane>
+                        <TabPane eventKey={2}>Parameters content</TabPane>
+                        <TabPane eventKey={3}>Versions content</TabPane>
+                      </TabContent>
+                    </div>
+                  </TabContainer>
+                </div>
+              </Grid.Col>
+            </Grid.Row>
+          </Grid>
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+}
 
 PluginBody.propTypes = {
   pluginData: PropTypes.shape({

--- a/src/components/Plugin/components/PluginBody/PluginBody.js
+++ b/src/components/Plugin/components/PluginBody/PluginBody.js
@@ -8,15 +8,12 @@ import {
   Grid, Nav, NavItem, TabContainer, TabContent, TabPane,
 } from 'patternfly-react';
 
-
 import './PluginBody.css';
 import { CopyURLButton } from '../../../general/CopyURLButton';
 
 const PluginBody = ({ pluginData }) => {
   const [readme, setReadme] = useState();
   const [repoData, setRepoData] = useState();
-
-  console.log(pluginData);
 
   const fetchReadme = useCallback(async (repo) => {
     const data = await fetch(`https://api.github.com/repos/${repo}/community/profile`)
@@ -97,6 +94,7 @@ const PluginBody = ({ pluginData }) => {
                                   {pluginData.authors}
                                 </a>
                                 <div className="plugin-body-contributors-all">
+                                  <br/>
                                   <a className="pf-m-link" href={`${pluginData.public_repo}/graphs/contributors`}>
                                     View all contributors...
                                   </a>

--- a/src/components/Plugin/components/PluginBody/PluginBody.js
+++ b/src/components/Plugin/components/PluginBody/PluginBody.js
@@ -16,6 +16,8 @@ const PluginBody = ({ pluginData }) => {
   const [readme, setReadme] = useState();
   const [repoData, setRepoData] = useState();
 
+  console.log(pluginData);
+
   const fetchReadme = useCallback(async (repo) => {
     const data = await fetch(`https://api.github.com/repos/${repo}/community/profile`)
     const rm = await fetch((await data.json()).files.readme.url)
@@ -95,7 +97,7 @@ const PluginBody = ({ pluginData }) => {
                                   {pluginData.authors}
                                 </a>
                                 <div className="plugin-body-contributors-all">
-                                  <a className="pf-m-link" href={repoData ? repoData.contributors_url : ''}>
+                                  <a className="pf-m-link" href={`${pluginData.public_repo}/graphs/contributors`}>
                                     View all contributors...
                                   </a>
                                 </div>
@@ -114,7 +116,7 @@ const PluginBody = ({ pluginData }) => {
                               </div>
                               <div className="plugin-body-detail-section">
                                 <h4>Date added</h4>
-                                7 July 2020
+                                {(new Date(pluginData.creation_date)).toDateString()}
                               </div>
                             </div>
                           </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9444,6 +9444,11 @@ marked@^0.7.0:
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.7.0.tgz#b64201f051d271b1edc10a04d1ae9b74bb8e5c0e"
   integrity sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==
 
+marked@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-2.0.3.tgz#3551c4958c4da36897bda2a16812ef1399c8d6b0"
+  integrity sha512-5otztIIcJfPc2qGTN8cVtOJEjNJZ0jwa46INMagrYfk0EvqtRuEHLsEe0LrFS0/q+ZRKT0+kXK7P2T1AN5lWRA==
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"


### PR DESCRIPTION
Fixes: #160

Handle any Promise rejection by `fetchPluginData()` in the `componentDidMount` lifecycle method of `src/components/Plugin/Plugin.js`. Return a 404 screen if after loading there is no pluginData.

![Screenshot (54)](https://user-images.githubusercontent.com/35369637/115143602-03746480-a066-11eb-861b-711934dfd88a.png)

## Overview of changes
These fixes focus on making the Plugin component more relevant and useable.
1. Fetching repository data from Github public API to use for populating relevant fields.
2. Fetch README from public repo community profile from Github public API to display as plugin documentation.
3. Display README as Markdown using package [marked](https://www.npmjs.com/package/marked).
4. Fixed many layout issues in PluginBody and made the component slightly more mobile friendly.

### Images
![Screenshot (52)](https://user-images.githubusercontent.com/35369637/115142766-29e3d100-a061-11eb-8142-0d67cd0916d2.png)

## Work in Progress
With further discussion more changes will be added according to what direction is to be taken. 
This is not the final state of this work.