### PR TITLE
include contribute to chrisstore link in footer'

### DIFF
--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -33,7 +33,7 @@ const Footer = () => (
           </div>
            <div className="footer-link">
             <a href="https://github.com/FNNDSC/ChRIS_store_ui">
-              Contribute to ChRIS Store
+              Contribute
             </a>
           </div>
           <div className="footer-link">

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -31,6 +31,11 @@ const Footer = () => (
               Report an Issue
             </a>
           </div>
+           <div className="footer-link">
+            <a href="https://github.com/FNNDSC/ChRIS_store_ui">
+              Contribute to ChRIS Store
+            </a>
+          </div>
           <div className="footer-link">
             <a href="mailto:dev@babyMRI.org?subject=ChRIS Store Plugin Request">
               Request a plugin


### PR DESCRIPTION
@jennydaman @mairin Includes a Contribute link on the footer which  redirects to the chris_store  repo which enables interested uses to be able to contribute
![Screenshot from 2021-05-01 07-08-53](https://user-images.githubusercontent.com/25798915/116770403-5a0d7580-aa4c-11eb-8ecc-9e2836b7e43d.png)
