### PR TITLE
CopyToClipboard: tooltip upgraded to pf4

### DIFF
--- a/src/components/Developers/components/CopyToClipboard/CopyToClipboard.js
+++ b/src/components/Developers/components/CopyToClipboard/CopyToClipboard.js
@@ -1,14 +1,24 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Clipboard from 'react-clipboard.js';
-import { Icon, OverlayTrigger, Tooltip } from 'patternfly-react';
+import { Icon } from 'patternfly-react';
 import './CopyToClipboard.css';
+import { Tooltip } from '@patternfly/react-core';
+import {CopyToClipboard as Clipboard} from 'react-copy-to-clipboard';
 
 class CopyToClipboard extends Component {
   constructor(props) {
     super(props);
     this.overlayTrigger = React.createRef();
     this.showTooltip = this.showTooltip.bind(this);
+    this.state = {isClicked:false};
+    this.changeClicked = this.changeClicked.bind(this);
+  }
+  
+  changeClicked() {
+    this.setState({isClicked:true});
+    setTimeout (()=>{
+      this.setState({isClicked:false})
+    },2000)
   }
 
   showTooltip() {
@@ -18,25 +28,16 @@ class CopyToClipboard extends Component {
 
   render() {
     return (
-      <OverlayTrigger
-        placement="bottom"
-        ref={this.overlayTrigger}
-        onClick={this.showTooltip}
-        overlay={(
-          <Tooltip
-            id="copiedTooltip"
-          >
-            <strong>Copied!</strong>
-          </Tooltip>
-        )}
-      >
+      <Tooltip
+        content={this.state.isClicked ? <strong>Copied</strong> : <strong>Copy</strong>}>
         <Clipboard
           className="copy-to-clipboard-btn btn btn-large"
-          data-clipboard-text={this.props.clipboardText}
+          text={this.props.clipboardText}
+          onCopy={this.changeClicked}
         >
           <Icon name="copy" />
         </Clipboard>
-      </OverlayTrigger>
+      </Tooltip>
     );
   }
 }


### PR DESCRIPTION
Fixes: #101 
1- Used CopyToClipboard feature from react-copy-to-clipboard.
2- Upgraded tooltip from pf3 to pf4.