### PR TITLE
Hotfix/quickstart layout

### DIFF
--- a/src/components/Developers/components/DeveloperCTA/DeveloperCTA.css
+++ b/src/components/Developers/components/DeveloperCTA/DeveloperCTA.css
@@ -1,6 +1,6 @@
 #developer-cta {
   /* color */
-  padding: 6em 2em;
+  padding: 3em;
   max-height: 100vh;
   background: #393f44;
   background: var(--pf-black-800);
@@ -10,7 +10,6 @@
   background-repeat: no-repeat;
   background-size: cover;
   background-position: center;
-  padding: 6em 3em;
 }
 
 @media (max-width: 425px) {

--- a/src/components/Developers/components/DeveloperCTA/DeveloperCTA.css
+++ b/src/components/Developers/components/DeveloperCTA/DeveloperCTA.css
@@ -1,7 +1,7 @@
 #developer-cta {
   /* color */
   padding: 6em 2em;
-
+  max-height: 100vh;
   background: #393f44;
   background: var(--pf-black-800);
   background: linear-gradient(135deg, #4d5258, #393f44);
@@ -11,6 +11,13 @@
   background-size: cover;
   background-position: center;
   padding: 6em 3em;
+}
+
+@media (max-width: 425px) {
+  #developer-cta {
+    min-height: 55rem;
+    box-sizing: content-box;
+  }
 }
 
 #developer-cta-header {

--- a/src/components/Developers/components/DeveloperCTA/DeveloperCTA.jsx
+++ b/src/components/Developers/components/DeveloperCTA/DeveloperCTA.jsx
@@ -8,7 +8,7 @@ import ConnectedDeveloperSignup from '../DeveloperSignup/DeveloperSignup';
 import ChrisStore from '../../../../store/ChrisStore';
 
 export const DeveloperCTA = ({ store }) => (
-  <Bullseye style={{ padding: '3em' }} id="developer-cta">
+  <Bullseye id="developer-cta">
     <Grid style={{ maxWidth: '1200px' }} hasGutter>
       <GridItem lg={6} xs={12}>
         <div id="developer-cta-header">


### PR DESCRIPTION
Below is the a short video  of what the page looked like before. The footer was also in the wrong location (above the <Instructions /> component). 


https://user-images.githubusercontent.com/34360644/140579636-63dc7f0e-40d6-4467-b10a-9275331c7257.mov

Link to the full video of the page layout and css issue: https://www.loom.com/share/90754b57cf1545a3ba3e613a5ccb6eb2 (it was too large to attach)

In this PR I also moved the inline style to the stylesheet.
