### PR TITLE
Bugfix plugins counter / paginationOffset

### DIFF
--- a/src/components/Plugins/Plugins.jsx
+++ b/src/components/Plugins/Plugins.jsx
@@ -360,8 +360,7 @@ export class Plugins extends Component {
           onClick={() => {
             this.setState({ loading: true });
             this.refreshPluginList({
-              // offset: paginationOffset + paginationLimit
-              offset: 45
+              offset: paginationOffset + paginationLimit
             })
           }}>
           Next
@@ -418,16 +417,7 @@ export class Plugins extends Component {
                                 {pluginsCount} plugins found
                             </p>
                             Showing {plugins.totalCount === -1 ? 0 : paginationOffset + 1} to {' '}
-                            {
-                              // eslint-disable-next-line no-nested-ternary
-                              (paginationOffset + paginationLimit > plugins.totalCount) ?
-                                plugins.totalCount === -1 ? 0 : plugins.totalCount
-                                :
-                                (paginationOffset > 0) ?
-                                  paginationOffset
-                                  :
-                                  paginationLimit
-                            }
+                            {paginationLimit + paginationOffset >= pluginsCount ? pluginsCount : paginationLimit + paginationOffset}
                           </span>
                         )
                       }

--- a/src/components/Plugins/Plugins.jsx
+++ b/src/components/Plugins/Plugins.jsx
@@ -164,7 +164,7 @@ export class Plugins extends Component {
       this.showNotifications(new HttpApiCallError(error));
       return;
     }
-
+  
     // plugin list and category list are available always, even if not logged in
     const nextState = {
       loading: false,
@@ -360,7 +360,8 @@ export class Plugins extends Component {
           onClick={() => {
             this.setState({ loading: true });
             this.refreshPluginList({
-              offset: paginationOffset + paginationLimit
+              // offset: paginationOffset + paginationLimit
+              offset: 45
             })
           }}>
           Next
@@ -416,11 +417,11 @@ export class Plugins extends Component {
                             <p style={{ fontSize: '1.25em', margin: '0', color: 'black', fontWeight: '600' }}>
                                 {pluginsCount} plugins found
                             </p>
-                            Showing {paginationOffset + 1} to {' '}
+                            Showing {plugins.totalCount === -1 ? 0 : paginationOffset + 1} to {' '}
                             {
                               // eslint-disable-next-line no-nested-ternary
                               (paginationOffset + paginationLimit > plugins.totalCount) ?
-                                plugins.totalCount
+                                plugins.totalCount === -1 ? 0 : plugins.totalCount
                                 :
                                 (paginationOffset > 0) ?
                                   paginationOffset


### PR DESCRIPTION
Issue #268 

I know this issue got worked on 6 months ago but it's not merged yet and the issue hasn't been worked on since.

Before:
<img width="215" alt="Screen Shot 2022-10-28 at 1 32 26 PM" src="https://user-images.githubusercontent.com/91545659/198697788-ae20255a-9c3d-4623-916e-ecbddc3ee1dc.png">
![](https://user-images.githubusercontent.com/91545659/198698153-4a68071d-181e-4b62-8c90-3753493bbc21.png)


- Resolved the issue of not showing paginationOffset correctly
- Resolved showing 1 to -1 or 1 tot 1 when there aren't any plugins